### PR TITLE
 Add : 특정 Category의 최하위 카테고리 id 추출 로직 작성

### DIFF
--- a/Product/src/main/java/shop/msa/product/service/impl/CategoryServiceImpl.java
+++ b/Product/src/main/java/shop/msa/product/service/impl/CategoryServiceImpl.java
@@ -42,7 +42,30 @@ public class CategoryServiceImpl implements CategoryService {
         Category category = Category.createCategory(request.getName(), parent);
         categoryCommandPort.save(category);
         refreshCategoryCache();
+    }
 
+    public List<Long> findLowestCategoryIds(Long categoryId) {
+
+        CategoryResponse category = findCategoryById(categoryCache, categoryId);
+        if (category == null) {
+            throw new CustomException(ErrorCode.NON_EXISTENT_PARENT);
+        }
+
+        return category.extractLowestCategoryIds();
+    }
+
+    private CategoryResponse findCategoryById(List<CategoryResponse> categories, Long categoryId) {
+        for (CategoryResponse category : categories) {
+            if (category.getId().equals(categoryId)) {
+                return category;
+            } else {
+                CategoryResponse found = findCategoryById(category.getChild(), categoryId);
+                if (found != null) {
+                    return found;
+                }
+            }
+        }
+        return null;
     }
 
     @Override

--- a/Product/src/main/java/shop/msa/product/service/response/CategoryResponse.java
+++ b/Product/src/main/java/shop/msa/product/service/response/CategoryResponse.java
@@ -8,6 +8,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static java.util.stream.Collectors.toList;
+
 @Getter
 @AllArgsConstructor
 public class CategoryResponse {
@@ -33,5 +35,18 @@ public class CategoryResponse {
                         .map(CategoryResponse::of)
                         .collect(Collectors.toList())
         );
+    }
+
+    public List<Long> extractLowestCategoryIds () {
+
+        if (this.getChild() == null || this.getChild().isEmpty()) {
+            return List.of(this.getId());
+        }
+
+        return this.getChild()
+                .stream()
+                .map(CategoryResponse::extractLowestCategoryIds)
+                .flatMap(List::stream)
+                .collect(toList());
     }
 };


### PR DESCRIPTION
- CategoryCache에서 dfs로 탐색
   - 카테고리 개수는 매우 적기 때문에 categoryCache에서 dfs로 작성 (최대 12개)
   - db를 가지 않고, 메모리에 있는 것으로 작업합니다.
- 이후 child를 return합니다.