### PR TITLE
" Add : product 서버에서 cart에 상품 등록 비동기 로직 작성 "

### DIFF
--- a/Product/build.gradle
+++ b/Product/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     testImplementation 'org.projectlombok:lombok:1.18.26'
 

--- a/Product/src/main/java/shop/msa/product/config/WebClientConfig.java
+++ b/Product/src/main/java/shop/msa/product/config/WebClientConfig.java
@@ -1,0 +1,40 @@
+package shop.msa.product.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+import shop.msa.product.exception.CustomException;
+import shop.msa.product.exception.ErrorCode;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebClientConfig {
+
+    private final DiscoveryClient discoveryClient;
+
+    /**
+     * k8s에 올릴 시 서버 자동 증설 방식에 따라 WebClient를 Configuration으로 둘지,
+     * ProductServiceImpl에서 매번 getInstance를 해야하는지 확실하지 않음. (지식 부족)
+     * 1. host명으로 추적이 가능
+     *     - Bean으로 등록해서 설정할 수 있다.
+     *
+     * 2. 추적 불가
+     *     - 매번 Service에서 Instance 받아야 한다.
+     *
+     * 현재 코드는 Spring cloud에서 Cart를 찾아서 미리 WebClient에 설정해둠, 1번 버전임.
+     * [나중에 반드시 고쳐야 함]
+     */
+    @Bean
+    public WebClient cartWebClient() {
+
+        ServiceInstance instance = discoveryClient.getInstances("Cart")
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.INTERNAL_SERVER_ERROR));
+
+        return WebClient.builder().baseUrl(instance.getUri().toString() + "/cart/add").build();
+    }
+}

--- a/Product/src/main/java/shop/msa/product/controller/ProductController.java
+++ b/Product/src/main/java/shop/msa/product/controller/ProductController.java
@@ -2,9 +2,11 @@ package shop.msa.product.controller;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.netflix.eureka.http.WebClientEurekaHttpClient;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.reactive.function.client.WebClient;
 import shop.msa.product.controller.request.ProductCreateRequest;
 import shop.msa.product.response.CommonResponse;
 import shop.msa.product.service.ProductService;

--- a/Product/src/main/java/shop/msa/product/controller/ProductController.java
+++ b/Product/src/main/java/shop/msa/product/controller/ProductController.java
@@ -50,4 +50,15 @@ public class ProductController {
                         .data(Map.of("product", productService.getProduct(productId)))
                         .build());
     }
+
+    @PostMapping("/{productId}")
+    public ResponseEntity<CommonResponse> addToCart(@RequestHeader String name, @PathVariable Long productId) throws NoSuchFieldException, IllegalAccessException {
+
+        productService.addToCart(name, productId);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.builder()
+                        .message("장바구니에 추가되었습니다.")
+                        .build());
+    }
 }

--- a/Product/src/main/java/shop/msa/product/service/ProductService.java
+++ b/Product/src/main/java/shop/msa/product/service/ProductService.java
@@ -13,4 +13,6 @@ public interface ProductService {
     Page<ProductResponse> getProducts(Long categoryId, int pageNum);
 
     ProductInfoResponse getProduct(Long productId);
+
+    void addToCart(String name, Long productId);
 }

--- a/Product/src/main/java/shop/msa/product/service/impl/ProductServiceImpl.java
+++ b/Product/src/main/java/shop/msa/product/service/impl/ProductServiceImpl.java
@@ -1,10 +1,15 @@
 package shop.msa.product.service.impl;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cloud.client.ServiceInstance;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.util.UriComponentsBuilder;
 import shop.msa.product.domain.Category;
 import shop.msa.product.domain.Product;
 import shop.msa.product.domain.ProductCategory;
@@ -29,6 +34,7 @@ public class ProductServiceImpl implements ProductService {
     private final ProductQueryPort productQueryPort;
     private final CategoryQueryPort categoryQueryPort;
     private final CategoryService categoryService;
+    private final WebClient cartWebClient;
 
     @Override
     @Transactional
@@ -61,5 +67,15 @@ public class ProductServiceImpl implements ProductService {
 
         Product product = productQueryPort.findById(productId).orElseThrow(() -> new CustomException(ErrorCode.NON_EXISTENT_PRODUCT));
         return new ProductInfoResponse(product.getId(),product.getName(), product.getPrice(), product.getStock());
+    }
+
+    @Override
+    public void addToCart(String name, Long productId) {
+
+        cartWebClient.post()
+                .body(BodyInserters.empty())
+                .retrieve()
+                .bodyToMono(Void.class)
+                .subscribe();
     }
 }


### PR DESCRIPTION
- kafka 대신 WebClient를 선택한 이유
   - 카트에 상품을 추가하는 데이터가 분석 입장에서 유의미하지 않아 kafka에 적재하는 것이 낭비라고 판단했습니다.


 k8s에 올릴 시 서버 자동 증설 방식에 따라 WebClient를 Configuration으로 둘지,
ProductServiceImpl에서 매번 getInstance를 해야하는지 확실하지 않음. (지식 부족)
1. host명으로 추적이 가능
   - host이름을 미리 세팅해두고 Bean으로 등록해서 설정할 수 있다.

2. 추적 불가(포트까지 추적해야 하는 경우)
   - 매번 Service에서 Instance 받아야 한다.

 현재 코드는 DiscoveryClient를 통해 Cart를 찾아서 미리 WebClient에 설정해둠, 1번 버전.

local에서 테스트 시 Cart 서버가 먼저 올라와야 오류가 발생하지 않습니다.
 [나중에 반드시 고쳐야 함]

아직 별도의 유효성 검증 로직은 작성하지 않음
