### PR TITLE
feature-backend/product -> develop-backend

### DIFF
--- a/Product/build.gradle
+++ b/Product/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     testImplementation 'org.projectlombok:lombok:1.18.26'
 
+    implementation 'org.springframework.kafka:spring-kafka'
+
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.h2database:h2'

--- a/Product/src/main/java/shop/msa/product/config/KafkaConfig.java
+++ b/Product/src/main/java/shop/msa/product/config/KafkaConfig.java
@@ -1,0 +1,34 @@
+package shop.msa.product.config;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaConfig {
+
+    @Value(value = "${producers.bootstrap-servers}")
+    private String bootstrapServers;
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class.getName());
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+    @Bean
+    public KafkaTemplate kafkaTemplate()
+    {
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/Product/src/main/java/shop/msa/product/controller/ProductController.java
+++ b/Product/src/main/java/shop/msa/product/controller/ProductController.java
@@ -7,10 +7,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.reactive.function.client.WebClient;
+import shop.msa.product.controller.request.OrderProductRequest;
 import shop.msa.product.controller.request.ProductCreateRequest;
 import shop.msa.product.response.CommonResponse;
 import shop.msa.product.service.ProductService;
 
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -59,6 +61,17 @@ public class ProductController {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(CommonResponse.builder()
                         .message("장바구니에 추가되었습니다.")
+                        .build());
+    }
+
+    @PostMapping("/order")
+    public ResponseEntity<CommonResponse> order(@RequestHeader String username, List<OrderProductRequest> orders) {
+
+        productService.order(username, orders);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(CommonResponse.builder()
+                        .message("주문이 접수되었습니다.")
                         .build());
     }
 }

--- a/Product/src/main/java/shop/msa/product/controller/ProductController.java
+++ b/Product/src/main/java/shop/msa/product/controller/ProductController.java
@@ -65,7 +65,7 @@ public class ProductController {
     }
 
     @PostMapping("/order")
-    public ResponseEntity<CommonResponse> order(@RequestHeader String username, List<OrderProductRequest> orders) {
+    public ResponseEntity<CommonResponse> order(@RequestHeader String username, @RequestBody List<OrderProductRequest> orders) {
 
         productService.order(username, orders);
 

--- a/Product/src/main/java/shop/msa/product/controller/request/OrderProductRequest.java
+++ b/Product/src/main/java/shop/msa/product/controller/request/OrderProductRequest.java
@@ -1,0 +1,18 @@
+package shop.msa.product.controller.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+
+@Getter
+public class OrderProductRequest {
+
+    @NotBlank(message = "productId가 존재하지 않습니다.")
+    private Long productId;
+
+    @NotBlank(message = "productName이 존재하지 않습니다.")
+    private String productName;
+
+    @Positive(message = "1개 이상 선택하지 않은 상품이 존재합니다.")
+    private int quantity;
+}

--- a/Product/src/main/java/shop/msa/product/domain/Product.java
+++ b/Product/src/main/java/shop/msa/product/domain/Product.java
@@ -54,4 +54,10 @@ public class Product {
     public void canAddToCart() {
         if (this.stock <= 0) throw new CustomException(ErrorCode.OUT_OF_STOCK);
     }
+
+    public void canBuy(int quantity) {
+
+        canAddToCart();
+        if (this.stock < quantity) throw new CustomException(ErrorCode.INSUFFICIENT_STOCK);
+    }
 }

--- a/Product/src/main/java/shop/msa/product/domain/event/OrderCreateEvent.java
+++ b/Product/src/main/java/shop/msa/product/domain/event/OrderCreateEvent.java
@@ -1,0 +1,18 @@
+package shop.msa.product.domain.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import shop.msa.product.controller.request.OrderProductRequest;
+
+import java.util.List;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class OrderCreateEvent {
+
+    private String username;
+
+    private List<OrderProductRequest> orderProducts;
+}

--- a/Product/src/main/java/shop/msa/product/exception/ErrorCode.java
+++ b/Product/src/main/java/shop/msa/product/exception/ErrorCode.java
@@ -16,7 +16,8 @@ public enum ErrorCode {
     DUPLICATE_PRODUCT(HttpStatus.BAD_REQUEST, "중복된 상품 이름입니다."),
     NON_EXISTENT_PRODUCT(HttpStatus.BAD_REQUEST, "존재하지 않는 상품입니다." ),
     OUT_OF_STOCK(HttpStatus.BAD_REQUEST, "품절된 상품입니다."),
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error");
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "Internal Server Error"),
+    INSUFFICIENT_STOCK(HttpStatus.BAD_REQUEST, "상품의 재고가 부족합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/Product/src/main/java/shop/msa/product/repository/ProductJpaRepository.java
+++ b/Product/src/main/java/shop/msa/product/repository/ProductJpaRepository.java
@@ -19,4 +19,6 @@ public interface ProductJpaRepository extends JpaRepository<Product, Long> {
 
     @Query(countQuery = "SELECT count(distinct(pc.id)) FROM ProductCategory pc WHERE pc.id IN :ids")
     Page<Product> findDistinctByCategories_Category_IdIn(List<Long> ids, Pageable pageable);
+
+    List<Product> findByIdIn(List<Long> productIds);
 }

--- a/Product/src/main/java/shop/msa/product/repository/ProductRepository.java
+++ b/Product/src/main/java/shop/msa/product/repository/ProductRepository.java
@@ -43,4 +43,9 @@ public class ProductRepository implements ProductCommandPort, ProductQueryPort {
         return productJpaRepository.findById(productId);
     }
 
+    @Override
+    public List<Product> findByIdIn(List<Long> productIds) {
+        return productJpaRepository.findByIdIn(productIds);
+    }
+
 }

--- a/Product/src/main/java/shop/msa/product/service/KafkaProducerService.java
+++ b/Product/src/main/java/shop/msa/product/service/KafkaProducerService.java
@@ -1,0 +1,10 @@
+package shop.msa.product.service;
+
+import shop.msa.product.controller.request.OrderProductRequest;
+
+import java.util.List;
+
+public interface KafkaProducerService {
+
+    void occurOrderCreateEvent(String username, List<OrderProductRequest> orders);
+}

--- a/Product/src/main/java/shop/msa/product/service/ProductService.java
+++ b/Product/src/main/java/shop/msa/product/service/ProductService.java
@@ -1,9 +1,12 @@
 package shop.msa.product.service;
 
 import org.springframework.data.domain.Page;
+import shop.msa.product.controller.request.OrderProductRequest;
 import shop.msa.product.service.request.ProductServiceCreateRequest;
 import shop.msa.product.service.response.ProductInfoResponse;
 import shop.msa.product.service.response.ProductResponse;
+
+import java.util.List;
 
 
 public interface ProductService {
@@ -15,4 +18,6 @@ public interface ProductService {
     ProductInfoResponse getProduct(Long productId);
 
     void addToCart(String name, Long productId);
+
+    void order(String username, List<OrderProductRequest> orders);
 }

--- a/Product/src/main/java/shop/msa/product/service/cqrs/ProductQueryPort.java
+++ b/Product/src/main/java/shop/msa/product/service/cqrs/ProductQueryPort.java
@@ -17,4 +17,6 @@ public interface ProductQueryPort {
     Page<Product> findDistinctByCategories_Category_IdIn(List<Long> categoryIds, Pageable pageable);
 
     Optional<Product> findById(Long productId);
+
+    List<Product> findByIdIn(List<Long> productIds);
 }

--- a/Product/src/main/java/shop/msa/product/service/impl/KafkaProducerServiceImpl.java
+++ b/Product/src/main/java/shop/msa/product/service/impl/KafkaProducerServiceImpl.java
@@ -1,0 +1,43 @@
+package shop.msa.product.service.impl;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+import shop.msa.product.controller.request.OrderProductRequest;
+import shop.msa.product.domain.event.OrderCreateEvent;
+import shop.msa.product.service.KafkaProducerService;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KafkaProducerServiceImpl implements KafkaProducerService {
+
+    @Value("${producers.topic1.name}")
+    private String TOPIC_ORDER;
+
+    private final KafkaTemplate<String, OrderCreateEvent> kafkaTemplate;
+
+    @Override
+    public void occurOrderCreateEvent(String username, List<OrderProductRequest> orders) {
+
+        OrderCreateEvent event = new OrderCreateEvent(username, orders);
+        CompletableFuture<SendResult<String, OrderCreateEvent>> future = kafkaTemplate.send(TOPIC_ORDER, event);
+
+        future.whenComplete((result, ex) -> {
+            if (ex == null) {
+                RecordMetadata metadata = result.getRecordMetadata();
+                OrderCreateEvent e = result.getProducerRecord().value();
+                log.info("Sent create order message by {}, with offset = {} ", e.getUsername(), metadata.offset());
+            } else {
+                log.error("Unable to send create order message by {}, due to : {}", event.getUsername(), ex.getMessage());
+            }
+        });
+    }
+}

--- a/Product/src/main/java/shop/msa/product/service/impl/ProductServiceImpl.java
+++ b/Product/src/main/java/shop/msa/product/service/impl/ProductServiceImpl.java
@@ -17,6 +17,7 @@ import shop.msa.product.domain.ProductCategory;
 import shop.msa.product.exception.CustomException;
 import shop.msa.product.exception.ErrorCode;
 import shop.msa.product.service.CategoryService;
+import shop.msa.product.service.KafkaProducerService;
 import shop.msa.product.service.ProductService;
 import shop.msa.product.service.cqrs.CategoryQueryPort;
 import shop.msa.product.service.cqrs.ProductCommandPort;
@@ -39,6 +40,7 @@ public class ProductServiceImpl implements ProductService {
     private final CategoryQueryPort categoryQueryPort;
     private final CategoryService categoryService;
     private final WebClient cartWebClient;
+    private final KafkaProducerService kafkaProducerService;
 
     @Override
     @Transactional
@@ -104,6 +106,8 @@ public class ProductServiceImpl implements ProductService {
             int quantity = orders.get(i).getQuantity();
             p.canBuy(quantity);
         }
+
+        kafkaProducerService.occurOrderCreateEvent(username, orders);
 
     }
 

--- a/Product/src/main/resources/application.yml
+++ b/Product/src/main/resources/application.yml
@@ -17,6 +17,28 @@ spring:
     properties:
       hibernate:
         format_sql: true
+  kafka:
+    consumer:
+      bootstrap-servers: localhost:9092
+      group-id: foo0
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+    producer:
+      bootstrap-servers: localhost:9092
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.apache.kafka.common.serialization.StringSerializer
+
+producers:
+  bootstrap-servers: localhost:9092
+  topic1:
+    name: order_create
+
+#consumer:
+#  topic1:
+#    name:
+#  groupid:
+#    name:
 
 eureka:
   client:


### PR DESCRIPTION
kafka 전용 docker compose는 추후 업로드 예정(세부 설정을 마친 후 )

- **상품 -> 주문 서버로의 로직을 실행**

- 주문 -> 상품 서버로의 로직을 실행하지 않은 이유
  - 어차피 상품 서버로 재고를 확인하러 가야 하므로, product에서부터 처리하기로 결정
  - 만약 주문 서버가 먼저 받는 경우 Order -> Product -> Order의 순서가 비효율적이라고 판단하였음.

- kafka 응답 확인 : CompletableFuture의 whenComplete(result, ex)
  - 이를 통해 정상, 실패의 경우를 핸들링한다. (별도의 비즈니스 로직 미작성 상태)
  - ListenableFuture는 Springboot 3.x 버전에서 deprecated되어 있어서 CompletableFuture로 대체

- 예시 응답 확인 (kafka ui)
![image](https://github.com/kksjae-hyyejji/MSA_Service/assets/57981401/21bace79-cbf2-42bb-9ef9-103ad37df535)


아직 Consumer 로직은 작성하지 않음.